### PR TITLE
Removing incentive multiplier

### DIFF
--- a/contracts/global/Constants.sol
+++ b/contracts/global/Constants.sol
@@ -96,11 +96,6 @@ library Constants {
     /// @dev Liquidation dust setting used during fCash liquidation
     int256 internal constant LIQUIDATION_DUST = 10;
 
-    /// @dev Annual incentive multiplier as a percentage
-    uint256 internal constant ANNUAL_INCENTIVE_MULTIPLIER_PERCENT = 50;
-    /// @dev Caps the max incentive multiplier to 2 years (i.e. 1 + 2 years * 0.5 == 2)
-    uint256 internal constant MAX_INCENTIVE_MULTIPLIER = 2e8;
-
     /* Internal Storage Slot Offsets */
     // Internally used storage slots are set at 1000000 offset from the solidity provisioned storage slots to minimize
     // the possibility of clashing.

--- a/contracts/internal/balances/Incentives.sol
+++ b/contracts/internal/balances/Incentives.sol
@@ -9,14 +9,12 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 library Incentives {
     using SafeMath for uint256;
 
-    /// @dev Notional incentivizes long term holding of nTokens by adding a multiplier to the tokens
-    /// accrued over time. The formula is:
-    ///     incentivesToClaim = (tokenBalance / totalSupply) * emissionRatePerYear * proRataYears * multiplier
-    ///     where multiplier is:
-    ///         1 + (proRataYears * multiplierConstant)
-    ///     and proRataYears is (timeSinceLastClaim / YEAR) * INTERNAL_TOKEN_PRECISION
-    /// @return (emissionRatePerYear * proRataYears * multiplier), decimal basis is (1e8 * 1e8 * 1e8 = 1e24)
-    function _getIncentiveMultiplier(uint256 timeSinceLastClaim, uint256 emissionRatePerYear)
+    /// @dev Notional incentivizes nTokens using the formula:
+    ///     incentivesToClaim = (tokenBalance / totalSupply) * emissionRatePerYear * proRataYears
+    ///     where proRataYears is:
+    ///         (timeSinceLastClaim / YEAR) * INTERNAL_TOKEN_PRECISION
+    /// @return (emissionRatePerYear * proRataYears), decimal basis is (1e8 * 1e8 = 1e16)
+    function _getIncentiveRate(uint256 timeSinceLastClaim, uint256 emissionRatePerYear)
         private
         pure
         returns (uint256)
@@ -25,19 +23,7 @@ library Incentives {
         uint256 proRataYears =
             timeSinceLastClaim.mul(uint256(Constants.INTERNAL_TOKEN_PRECISION)).div(Constants.YEAR);
 
-        // INTERNAL_TOKEN_PRECISION + (proRataYears * multiplierConstant)
-        uint256 multiplier =
-            proRataYears
-                .mul(Constants.ANNUAL_INCENTIVE_MULTIPLIER_PERCENT)
-                .div(uint256(Constants.PERCENTAGE_DECIMALS))
-                .add(uint256(Constants.INTERNAL_TOKEN_PRECISION));
-
-        // Cap the multiplier to some number of years so it does not accrue too aggressively
-        if (multiplier > Constants.MAX_INCENTIVE_MULTIPLIER) {
-            multiplier = Constants.MAX_INCENTIVE_MULTIPLIER;
-        }
-
-        return proRataYears.mul(multiplier).mul(emissionRatePerYear);
+        return proRataYears.mul(emissionRatePerYear);
     }
 
     /// @notice Calculates the claimable incentives for a particular nToken and account
@@ -60,8 +46,8 @@ library Incentives {
         if (lastClaimTime == 0 || lastClaimTime >= blockTime) return (0, totalSupply);
         if (totalSupply == 0) return (0, 0);
 
-        uint256 incentiveMultiplier =
-            _getIncentiveMultiplier(
+        uint256 incentiveRate =
+            _getIncentiveRate(
                 // No overflow here, checked above
                 blockTime - lastClaimTime,
                 // Convert this to the appropriate denomination
@@ -71,18 +57,15 @@ library Incentives {
         // Returns the average supply between now and the previous mint time. This is done to dampen the effect of
         // total supply fluctuations when claiming tokens. For example, if someone minted nTokens when the supply was
         // at 100e8 and then claimed incentives when the supply was at 100_000e8, they would be diluted out of part of
-        // their token incentives. This will ensure that they claim with an average supply of 50050e8, which is better
+        // their token incentives. This will ensure that they claim with an average supply of 50_050e8, which is better
         // than not doing the average
         uint256 avgTotalSupply =
             totalSupply.add(lastClaimSupply.mul(uint256(Constants.INTERNAL_TOKEN_PRECISION))).div(
                 2
             );
 
-        uint256 incentivesToClaim = nTokenBalance.mul(incentiveMultiplier).div(avgTotalSupply);
-
-        incentivesToClaim = incentivesToClaim.div(
-            uint256(Constants.INTERNAL_TOKEN_PRECISION * Constants.INTERNAL_TOKEN_PRECISION)
-        );
+        uint256 incentivesToClaim = nTokenBalance.mul(incentiveRate).div(avgTotalSupply);
+        incentivesToClaim = incentivesToClaim.div(uint256(Constants.INTERNAL_TOKEN_PRECISION));
 
         return (incentivesToClaim, totalSupply);
     }

--- a/tests/internal/balances/test_incentives.py
+++ b/tests/internal/balances/test_incentives.py
@@ -29,9 +29,8 @@ class TestIncentives:
             accounts[1], 1_000_000e8, START_TIME, 50_000_000, START_TIME + SECONDS_IN_YEAR
         )
 
-        # After 1 year, 1% of the avg supply returns 1.5% of the tokens minted
-        # (1% * 1.5 multiplier)
-        assert claimed == 1.5e8
+        # After 1 year, 1% of the avg supply returns 1% of the tokens minted
+        assert claimed == 1e8
 
     def test_incentives_zero_time(self, incentives, accounts):
         incentives.setNTokenParameters(1, accounts[1], 150_000_000e8, 100)
@@ -49,9 +48,8 @@ class TestIncentives:
             accounts[1], 1_000_000e8, START_TIME, 50_000_000, START_TIME + SECONDS_IN_YEAR * 2
         )
 
-        # After 2 years, 1% of the avg supply returns 4% of the tokens minted
-        # (1% * 2 * 2 multiplier)
-        assert claimed == 4e8
+        # After 2 years, 1% of the avg supply returns 2% of the tokens minted
+        assert claimed == 2e8
 
     def test_incentives_three_years(self, incentives, accounts):
         incentives.setNTokenParameters(1, accounts[1], 150_000_000e8, 100)
@@ -60,7 +58,5 @@ class TestIncentives:
             accounts[1], 1_000_000e8, START_TIME, 50_000_000, START_TIME + SECONDS_IN_YEAR * 3
         )
 
-        # After 3 years, 1% of the avg supply returns 6% of the tokens minted
-        # (1% * 3 * 2 multiplier)
-        # Tests that the multiplier does not increase to 2.5
-        assert claimed == 6e8
+        # After 3 years, 1% of the avg supply returns 3% of the tokens minted
+        assert claimed == 3e8

--- a/tests/stateful/test_ntoken_actions.py
+++ b/tests/stateful/test_ntoken_actions.py
@@ -523,7 +523,7 @@ def test_mint_incentives(environment, accounts):
     balanceAfter = environment.noteERC20.balanceOf(accounts[0])
 
     assert balanceAfter - balanceBefore == incentivesClaimed
-    assert pytest.approx(incentivesClaimed, rel=1e-4) == 150000e8 * 3
+    assert pytest.approx(incentivesClaimed, rel=1e-4) == 100000e8 * 3
     assert (
         environment.notional.nTokenGetClaimableIncentives(accounts[0].address, txn.timestamp) == 0
     )
@@ -548,7 +548,7 @@ def test_mint_bitmap_incentives(environment, accounts):
     balanceAfter = environment.noteERC20.balanceOf(accounts[0])
 
     assert balanceAfter - balanceBefore == incentivesClaimed
-    assert pytest.approx(incentivesClaimed, rel=1e-4) == 150000e8 * 3
+    assert pytest.approx(incentivesClaimed, rel=1e-4) == 100000e8 * 3
     assert environment.notional.nTokenGetClaimableIncentives(accounts[0].address, chain.time()) == 0
 
     (_, _, mintTimeAfterZero) = environment.notional.getAccountBalance(currencyId, accounts[0])


### PR DESCRIPTION
Removes the incentive multiplier because it does not make economic sense if emission rates will be changing.