### PR TITLE
Upgrading proxy to OZ UUPS and adding a pausability

### DIFF
--- a/contracts/external/PausedRouter.sol
+++ b/contracts/external/PausedRouter.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../global/StorageLayoutV1.sol";
+import "../proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * Read only version of the Router that can only be upgraded by governance. Used in emergency when the system must
+ * be paused for some reason.
+ */
+contract PauseRouter is StorageLayoutV1, UUPSUpgradeable {
+    address public immutable VIEWS;
+
+    constructor(
+        address views_
+    ) {
+        VIEWS = views_;
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override {
+        // This is only true during a rollback check when the pause router is downgraded
+        bool isRollbackCheck = rollbackRouterImplementation != address(0) && newImplementation == rollbackRouterImplementation;
+
+        require(owner == msg.sender || (msg.sender == pauseGuardian && isRollbackCheck),
+            "Unauthorized upgrade"
+        );
+
+        // Clear this storage slot so the guardian cannot upgrade back to the previous router,
+        // requires governance to do so.
+        rollbackRouterImplementation == address(0);
+    }
+
+    /// @dev Delegates the current call to `implementation`.
+    /// This function does not return to its internal call site, it will return directly to the external caller.
+    function _delegate(address implementation) private {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+                // delegatecall returns 0 on error.
+                case 0 {
+                    revert(0, returndatasize())
+                }
+                default {
+                    return(0, returndatasize())
+                }
+        }
+    }
+
+    fallback() external payable {
+        _delegate(VIEWS);
+    }
+}

--- a/contracts/external/PausedRouter.sol
+++ b/contracts/external/PausedRouter.sol
@@ -28,7 +28,7 @@ contract PauseRouter is StorageLayoutV1, UUPSUpgradeable {
 
         // Clear this storage slot so the guardian cannot upgrade back to the previous router,
         // requires governance to do so.
-        rollbackRouterImplementation == address(0);
+        rollbackRouterImplementation = address(0);
     }
 
     /// @dev Delegates the current call to `implementation`.

--- a/contracts/external/Router.sol
+++ b/contracts/external/Router.sol
@@ -115,7 +115,6 @@ contract Router is StorageLayoutV1 {
             sig == nTokenAction.nTokenTransfer.selector ||
             sig == nTokenAction.nTokenTransferFrom.selector ||
             sig == nTokenAction.nTokenClaimIncentives.selector ||
-            sig == nTokenAction.nTokenGetClaimableIncentives.selector ||
             sig == nTokenAction.nTokenTransferApproveAll.selector ||
             sig == nTokenAction.nTokenPresentValueAssetDenominated.selector ||
             sig == nTokenAction.nTokenPresentValueUnderlyingDenominated.selector

--- a/contracts/external/Router.sol
+++ b/contracts/external/Router.sol
@@ -14,7 +14,7 @@ import "./actions/LiquidatefCashAction.sol";
 import "./actions/LiquidateCurrencyAction.sol";
 import "../global/StorageLayoutV1.sol";
 import "../global/Types.sol";
-import "@openzeppelin/contracts/proxy/TransparentUpgradeableProxy.sol";
+import "../proxy/utils/UUPSUpgradeable.sol";
 
 /**
  * @notice Sits behind an upgradeable proxy and routes methods to an appropriate implementation contract. All storage
@@ -187,7 +187,9 @@ contract Router is StorageLayoutV1 {
             sig == GovernanceAction.updateDepositParameters.selector ||
             sig == GovernanceAction.updateInitializationParameters.selector ||
             sig == GovernanceAction.updateTokenCollateralParameters.selector ||
-            sig == GovernanceAction.updateGlobalTransferOperator.selector
+            sig == GovernanceAction.updateGlobalTransferOperator.selector ||
+            sig == UUPSUpgradeable.upgradeTo.selector ||
+            sig == UUPSUpgradeable.upgradeToAndCall.selector
         ) {
             return GOVERNANCE;
         }
@@ -231,14 +233,4 @@ contract Router is StorageLayoutV1 {
 
     // NOTE: receive() is overridden in "nTransparentUpgradeableProxy" to allow for eth transfers to succeed
     // with limited gas so that is the contract that must be deployed, not the regular OZ proxy.
-}
-
-contract nTransparentUpgradeableProxy is TransparentUpgradeableProxy {
-    constructor(
-        address _logic,
-        address admin_,
-        bytes memory _data
-    ) TransparentUpgradeableProxy(_logic, admin_, _data) {}
-
-    receive() external payable override {}
 }

--- a/contracts/external/Router.sol
+++ b/contracts/external/Router.sol
@@ -65,7 +65,7 @@ contract Router is StorageLayoutV1 {
         cETH = cETH_;
     }
 
-    function initialize(address owner_) public {
+    function initialize(address owner_, address pauseRouter_, address pauseGuardian_) public {
         // Cannot re-initialize once the contract has been initialized, ownership transfer does not
         // allow address to be set back to zero
         require(owner == address(0), "R: already initialized");
@@ -91,6 +91,9 @@ contract Router is StorageLayoutV1 {
         require(status);
 
         owner = owner_;
+        // The pause guardian may downgrade the router to the pauseRouter
+        pauseRouter = pauseRouter_;
+        pauseGuardian = pauseGuardian_;
     }
 
     /// @notice Returns the implementation contract for the method signature
@@ -231,6 +234,5 @@ contract Router is StorageLayoutV1 {
         _delegate(getRouterImplementation(msg.sig));
     }
 
-    // NOTE: receive() is overridden in "nTransparentUpgradeableProxy" to allow for eth transfers to succeed
-    // with limited gas so that is the contract that must be deployed, not the regular OZ proxy.
+    // NOTE: receive() is overridden in "nProxy" to allow for eth transfers to succeed
 }

--- a/contracts/external/actions/GovernanceAction.sol
+++ b/contracts/external/actions/GovernanceAction.sol
@@ -7,13 +7,14 @@ import "../../internal/markets/CashGroup.sol";
 import "../../internal/nTokenHandler.sol";
 import "../../internal/balances/TokenHandler.sol";
 import "../../global/StorageLayoutV1.sol";
+import "../../proxy/utils/UUPSUpgradeable.sol";
 import "../adapters/nTokenERC20Proxy.sol";
 import "interfaces/notional/AssetRateAdapter.sol";
 import "interfaces/notional/NotionalGovernance.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 
 /// @notice Governance methods can only be called by the governance contract
-contract GovernanceAction is StorageLayoutV1, NotionalGovernance {
+contract GovernanceAction is StorageLayoutV1, NotionalGovernance, UUPSUpgradeable {
     /// @dev Throws if called by any account other than the owner.
     modifier onlyOwner() {
         require(owner == msg.sender, "Ownable: caller is not the owner");
@@ -27,6 +28,9 @@ contract GovernanceAction is StorageLayoutV1, NotionalGovernance {
         emit OwnershipTransferred(owner, newOwner);
         owner = newOwner;
     }
+
+    /// @dev Only the owner may upgrade the contract
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner { }
 
     /// @notice Lists a new currency along with its exchange rate to ETH
     /// @dev emit:ListCurrency emit:UpdateETHRate

--- a/contracts/external/actions/nTokenAction.sol
+++ b/contracts/external/actions/nTokenAction.sol
@@ -207,64 +207,6 @@ contract nTokenAction is StorageLayoutV1, nTokenERC20 {
         return totalIncentivesClaimed;
     }
 
-    /// @notice Returns the claimable incentives for all nToken balances
-    /// @param account The address of the account which holds the tokens
-    /// @param blockTime The block time when incentives will be minted
-    /// @return Incentives an account is eligible to claim
-    function nTokenGetClaimableIncentives(address account, uint256 blockTime)
-        external
-        view
-        override
-        returns (uint256)
-    {
-        AccountContext memory accountContext = AccountContextHandler.getAccountContext(account);
-        BalanceState memory balanceState;
-        uint256 totalIncentivesClaimable;
-
-        if (accountContext.bitmapCurrencyId != 0) {
-            balanceState.loadBalanceState(account, accountContext.bitmapCurrencyId, accountContext);
-            if (balanceState.storedNTokenBalance > 0) {
-                // prettier-ignore
-                (
-                    uint256 incentivesToClaim,
-                    /* totalSupply */
-                ) = Incentives.calculateIncentivesToClaim(
-                    nTokenHandler.nTokenAddress(balanceState.currencyId),
-                    uint256(balanceState.storedNTokenBalance),
-                    balanceState.lastClaimTime,
-                    balanceState.lastClaimSupply,
-                    blockTime
-                );
-                totalIncentivesClaimable = totalIncentivesClaimable.add(incentivesToClaim);
-            }
-        }
-
-        bytes18 currencies = accountContext.activeCurrencies;
-        while (currencies != 0) {
-            uint256 currencyId = uint256(uint16(bytes2(currencies) & Constants.UNMASK_FLAGS));
-            balanceState.loadBalanceState(account, currencyId, accountContext);
-
-            if (balanceState.storedNTokenBalance > 0) {
-                // prettier-ignore
-                (
-                    uint256 incentivesToClaim,
-                    /* totalSupply */
-                ) = Incentives.calculateIncentivesToClaim(
-                    nTokenHandler.nTokenAddress(balanceState.currencyId),
-                    uint256(balanceState.storedNTokenBalance),
-                    balanceState.lastClaimTime,
-                    balanceState.lastClaimSupply,
-                    blockTime
-                );
-                totalIncentivesClaimable = totalIncentivesClaimable.add(incentivesToClaim);
-            }
-
-            currencies = currencies << 16;
-        }
-
-        return totalIncentivesClaimable;
-    }
-
     /// @notice Returns the present value of the nToken's assets denominated in asset tokens
     function nTokenPresentValueAssetDenominated(uint16 currencyId)
         external

--- a/contracts/external/governance/NoteERC20.sol
+++ b/contracts/external/governance/NoteERC20.sol
@@ -278,7 +278,11 @@ contract NoteERC20 is Initializable, UUPSUpgradeable {
 
         // First check most recent balance
         if (checkpoints[account][nCheckpoints - 1].fromBlock <= blockNumber) {
-            return checkpoints[account][nCheckpoints - 1].votes;
+            return _add96(
+                checkpoints[account][nCheckpoints - 1].votes,
+                getUnclaimedVotes(account),
+                "Note::getPriorVotes: uint96 overflow"
+            );
         }
 
         // Next check implicit zero balance
@@ -318,6 +322,9 @@ contract NoteERC20 is Initializable, UUPSUpgradeable {
     /// @param account the address of the Notional account to check
     /// @return Total number of unclaimed tokens accrued on the Notional account
     function getUnclaimedVotes(address account) public view returns (uint96) {
+        // If the notional proxy is not set then there are no unclaimed votes
+        if (address(notionalProxy) == address(0)) return 0;
+
         uint256 votes = notionalProxy.nTokenGetClaimableIncentives(account, block.timestamp);
         require(votes <= type(uint96).max);
         return uint96(votes);

--- a/contracts/global/StorageLayoutV1.sol
+++ b/contracts/global/StorageLayoutV1.sol
@@ -28,7 +28,7 @@ contract StorageLayoutV1 {
     // This is set to an address of a router that can only call governance actions
     address public pauseGuardian;
     // On upgrades this is set in the case that the pause router is used to pass the rollback check
-    address public rollbackRouterImplementation;
+    address internal rollbackRouterImplementation;
 
     // A blanket allowance for a spender to transfer any of an account's nTokens. This would allow a user
     // to set an allowance on all nTokens for a particular integrating contract system.

--- a/contracts/global/StorageLayoutV1.sol
+++ b/contracts/global/StorageLayoutV1.sol
@@ -20,9 +20,15 @@ contract StorageLayoutV1 {
 
     /* Authentication Mappings */
     // This is set to the timelock contract to execute governance functions
-    address internal owner;
+    address public owner;
     // This is set to the governance token address
     address internal token;
+    // This is set to an address of a router that can only call governance actions
+    address public pauseRouter;
+    // This is set to an address of a router that can only call governance actions
+    address public pauseGuardian;
+    // On upgrades this is set in the case that the pause router is used to pass the rollback check
+    address public rollbackRouterImplementation;
 
     // A blanket allowance for a spender to transfer any of an account's nTokens. This would allow a user
     // to set an allowance on all nTokens for a particular integrating contract system.

--- a/contracts/proxy/ERC1967/ERC1967Proxy.sol
+++ b/contracts/proxy/ERC1967/ERC1967Proxy.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "../Proxy.sol";
+import "./ERC1967Upgrade.sol";
+
+/**
+ * @dev This contract implements an upgradeable proxy. It is upgradeable because calls are delegated to an
+ * implementation address that can be changed. This address is stored in storage in the location specified by
+ * https://eips.ethereum.org/EIPS/eip-1967[EIP1967], so that it doesn't conflict with the storage layout of the
+ * implementation behind the proxy.
+ */
+contract ERC1967Proxy is Proxy, ERC1967Upgrade {
+    /**
+     * @dev Initializes the upgradeable proxy with an initial implementation specified by `_logic`.
+     *
+     * If `_data` is nonempty, it's used as data in a delegate call to `_logic`. This will typically be an encoded
+     * function call, and allows initializating the storage of the proxy like a Solidity constructor.
+     */
+    constructor(address _logic, bytes memory _data) payable {
+        assert(_IMPLEMENTATION_SLOT == bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1));
+        _upgradeToAndCall(_logic, _data, false);
+    }
+
+    /**
+     * @dev Returns the current implementation address.
+     */
+    function _implementation() internal view virtual override returns (address impl) {
+        return ERC1967Upgrade._getImplementation();
+    }
+}

--- a/contracts/proxy/ERC1967/ERC1967Upgrade.sol
+++ b/contracts/proxy/ERC1967/ERC1967Upgrade.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "../utils/StorageSlot.sol";
+
+/**
+ * @dev This abstract contract provides getters and event emitting update functions for
+ * https://eips.ethereum.org/EIPS/eip-1967[EIP1967] slots.
+ *
+ * _Available since v4.1._
+ *
+ */
+abstract contract ERC1967Upgrade {
+    // This is the keccak-256 hash of "eip1967.proxy.rollback" subtracted by 1
+    bytes32 private constant _ROLLBACK_SLOT = 0x4910fdfa16fed3260ed0e7147f7cc6da11a60208b5b9406d12a635614ffd9143;
+
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /**
+     * @dev Emitted when the implementation is upgraded.
+     */
+    event Upgraded(address indexed implementation);
+
+    /**
+     * @dev Returns the current implementation address.
+     */
+    function _getImplementation() internal view returns (address) {
+        return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+    }
+
+    /**
+     * @dev Stores a new address in the EIP1967 implementation slot.
+     */
+    function _setImplementation(address newImplementation) private {
+        require(Address.isContract(newImplementation), "ERC1967: new implementation is not a contract");
+        StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;
+    }
+
+    /**
+     * @dev Perform implementation upgrade
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeTo(address newImplementation) internal {
+        _setImplementation(newImplementation);
+        emit Upgraded(newImplementation);
+    }
+
+    /**
+     * @dev Perform implementation upgrade with additional setup call.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeToAndCall(
+        address newImplementation,
+        bytes memory data,
+        bool forceCall
+    ) internal {
+        _upgradeTo(newImplementation);
+        if (data.length > 0 || forceCall) {
+            Address.functionDelegateCall(newImplementation, data);
+        }
+    }
+
+    /**
+     * @dev Perform implementation upgrade with security checks for UUPS proxies, and additional setup call.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeToAndCallSecure(
+        address newImplementation,
+        bytes memory data,
+        bool forceCall
+    ) internal {
+        address oldImplementation = _getImplementation();
+
+        // Initial upgrade and setup call
+        _setImplementation(newImplementation);
+        if (data.length > 0 || forceCall) {
+            Address.functionDelegateCall(newImplementation, data);
+        }
+
+        // Perform rollback test if not already in progress
+        StorageSlot.BooleanSlot storage rollbackTesting = StorageSlot.getBooleanSlot(_ROLLBACK_SLOT);
+        if (!rollbackTesting.value) {
+            // Trigger rollback using upgradeTo from the new implementation
+            rollbackTesting.value = true;
+            Address.functionDelegateCall(
+                newImplementation,
+                abi.encodeWithSignature("upgradeTo(address)", oldImplementation)
+            );
+            rollbackTesting.value = false;
+            // Check rollback was effective
+            require(oldImplementation == _getImplementation(), "ERC1967Upgrade: upgrade breaks further upgrades");
+            // Finally reset to the new implementation and log the upgrade
+            _upgradeTo(newImplementation);
+        }
+    }
+
+}

--- a/contracts/proxy/Proxy.sol
+++ b/contracts/proxy/Proxy.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internal call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback() external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive() external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {}
+}

--- a/contracts/proxy/nProxy.sol
+++ b/contracts/proxy/nProxy.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "./ERC1967/ERC1967Proxy.sol";
+
+contract nProxy is ERC1967Proxy {
+    constructor(
+        address _logic,
+        bytes memory _data
+    ) ERC1967Proxy(_logic, _data) {}
+
+    receive() external payable override {}
+
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+}

--- a/contracts/proxy/utils/StorageSlot.sol
+++ b/contracts/proxy/utils/StorageSlot.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Library for reading and writing primitive types to specific storage slots.
+ *
+ * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.
+ * This library helps with reading and writing to such slots without the need for inline assembly.
+ *
+ * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.
+ *
+ * Example usage to set ERC1967 implementation slot:
+ * ```
+ * contract ERC1967 {
+ *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+ *
+ *     function _getImplementation() internal view returns (address) {
+ *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+ *     }
+ *
+ *     function _setImplementation(address newImplementation) internal {
+ *         require(Address.isContract(newImplementation), "ERC1967: new implementation is not a contract");
+ *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;
+ *     }
+ * }
+ * ```
+ *
+ * _Available since v4.1 for `address`, `bool`, `bytes32`, and `uint256`._
+ */
+library StorageSlot {
+    struct AddressSlot {
+        address value;
+    }
+
+    struct BooleanSlot {
+        bool value;
+    }
+
+    struct Bytes32Slot {
+        bytes32 value;
+    }
+
+    struct Uint256Slot {
+        uint256 value;
+    }
+
+    /**
+     * @dev Returns an `AddressSlot` with member `value` located at `slot`.
+     */
+    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `BooleanSlot` with member `value` located at `slot`.
+     */
+    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `Bytes32Slot` with member `value` located at `slot`.
+     */
+    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `Uint256Slot` with member `value` located at `slot`.
+     */
+    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+}

--- a/contracts/proxy/utils/UUPSUpgradeable.sol
+++ b/contracts/proxy/utils/UUPSUpgradeable.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+import "../ERC1967/ERC1967Upgrade.sol";
+
+/**
+ * @dev An upgradeability mechanism designed for UUPS proxies. The functions included here can perform an upgrade of an
+ * {ERC1967Proxy}, when this contract is set as the implementation behind such a proxy.
+ *
+ * A security mechanism ensures that an upgrade does not turn off upgradeability accidentally, although this risk is
+ * reinstated if the upgrade retains upgradeability but removes the security mechanism, e.g. by replacing
+ * `UUPSUpgradeable` with a custom implementation of upgrades.
+ *
+ * The {_authorizeUpgrade} function must be overridden to include access restriction to the upgrade mechanism.
+ *
+ * _Available since v4.1._
+ */
+abstract contract UUPSUpgradeable is ERC1967Upgrade {
+    /**
+     * @dev Upgrade the implementation of the proxy to `newImplementation`.
+     *
+     * Calls {_authorizeUpgrade}.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function upgradeTo(address newImplementation) external virtual {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallSecure(newImplementation, bytes(""), false);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy to `newImplementation`, and subsequently execute the function call
+     * encoded in `data`.
+     *
+     * Calls {_authorizeUpgrade}.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable virtual {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallSecure(newImplementation, data, true);
+    }
+
+    /**
+     * @dev Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
+     * {upgradeTo} and {upgradeToAndCall}.
+     *
+     * Normally, this function will use an xref:access.adoc[access control] modifier such as {Ownable-onlyOwner}.
+     *
+     * ```solidity
+     * function _authorizeUpgrade(address) internal override onlyOwner {}
+     * ```
+     */
+    function _authorizeUpgrade(address newImplementation) internal virtual;
+}

--- a/interfaces/notional/INoteERC20.sol
+++ b/interfaces/notional/INoteERC20.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.7.0;
 
 interface INoteERC20 {

--- a/interfaces/notional/NotionalGovernance.sol
+++ b/interfaces/notional/NotionalGovernance.sol
@@ -16,8 +16,11 @@ interface NotionalGovernance {
     event UpdateTokenCollateralParameters(uint16 currencyId);
     event UpdateGlobalTransferOperator(address operator, bool approved);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event PauseRouterAndGuardianUpdated(address indexed pauseRouter, address indexed pauseGuardian);
 
     function transferOwnership(address newOwner) external;
+
+    function setPauseRouterAndGuardian(address pauseRouter_, address pauseGuardian_) external;
 
     function listCurrency(
         TokenStorage calldata assetToken,

--- a/interfaces/notional/NotionalProxy.sol
+++ b/interfaces/notional/NotionalProxy.sol
@@ -82,6 +82,9 @@ interface NotionalProxy is nTokenERC20, nERC1155Interface, NotionalGovernance, N
     function upgradeTo(address newImplementation) external;
     function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
     function getImplementation() external view returns (address);
+    function owner() external view returns (address);
+    function pauseRouter() external view returns (address);
+    function pauseGuardian() external view returns (address);
 
     /** Initialize Markets Action */
     function initializeMarkets(uint256 currencyId, bool isFirstInit) external;

--- a/interfaces/notional/NotionalProxy.sol
+++ b/interfaces/notional/NotionalProxy.sol
@@ -78,6 +78,11 @@ interface NotionalProxy is nTokenERC20, nERC1155Interface, NotionalGovernance, N
         int256[] fCashNotionalTransfer
     );
 
+    /** UUPS Upgradeable contract calls */
+    function upgradeTo(address newImplementation) external;
+    function upgradeToAndCall(address newImplementation, bytes memory data) external payable;
+    function getImplementation() external view returns (address);
+
     /** Initialize Markets Action */
     function initializeMarkets(uint256 currencyId, bool isFirstInit) external;
 

--- a/interfaces/notional/NotionalViews.sol
+++ b/interfaces/notional/NotionalViews.sol
@@ -131,4 +131,10 @@ interface NotionalViews {
         uint256 marketIndex,
         uint256 blockTime
     ) external view returns (int256, int256);
+
+    function nTokenGetClaimableIncentives(address account, uint256 blockTime)
+        external
+        view
+        returns (uint256);
+
 }

--- a/interfaces/notional/nTokenERC20.sol
+++ b/interfaces/notional/nTokenERC20.sol
@@ -43,11 +43,6 @@ interface nTokenERC20 {
 
     function nTokenClaimIncentives() external returns (uint256);
 
-    function nTokenGetClaimableIncentives(address account, uint256 blockTime)
-        external
-        view
-        returns (uint256);
-
     function nTokenPresentValueAssetDenominated(uint16 currencyId) external view returns (int256);
 
     function nTokenPresentValueUnderlyingDenominated(uint16 currencyId)

--- a/scripts/deployment.py
+++ b/scripts/deployment.py
@@ -13,6 +13,7 @@ from brownie import (
     MockAggregator,
     MockERC20,
     NoteERC20,
+    PauseRouter,
     Router,
     SettleAssetsExternal,
     TradingAction,
@@ -91,6 +92,7 @@ class TestEnvironment:
                 [self.deployer, self.notional.address],
                 [99_000_000e8, GovernanceConfig["initialBalances"]["NOTIONAL"]],
                 self.notional.address,
+                self.deployer.address,
                 {"from": self.deployer},
             )
 
@@ -212,6 +214,9 @@ class TestEnvironment:
         liquidateCurrencyAction = LiquidateCurrencyAction.deploy({"from": self.deployer})
         liquidatefCashAction = LiquidatefCashAction.deploy({"from": self.deployer})
 
+        # Deploy Pause Router
+        self.pauseRouter = PauseRouter.deploy(views.address, {"from": self.deployer})
+
         # Deploy router
         self.router = Router.deploy(
             governance.address,
@@ -229,7 +234,8 @@ class TestEnvironment:
         )
 
         initializeData = web3.eth.contract(abi=Router.abi).encodeABI(
-            fn_name="initialize", args=[self.deployer.address]
+            fn_name="initialize",
+            args=[self.deployer.address, self.pauseRouter.address, accounts[8].address],
         )
 
         self.proxy = nProxy.deploy(

--- a/tests/governance/test_governance.py
+++ b/tests/governance/test_governance.py
@@ -396,7 +396,7 @@ def test_pause_and_restart_router(environment, accounts):
 
     with brownie.reverts():
         # Still cannot upgrade to arbitrary implementation
-        environment.notional.upgradeTo(zeroAddress, {"from": accounts[8]})
+        environment.notional.upgradeTo(environment.router.address, {"from": accounts[8]})
 
     # Can call a view method
     environment.notional.getAccountPortfolio(accounts[0])

--- a/tests/governance/test_governance.py
+++ b/tests/governance/test_governance.py
@@ -66,6 +66,7 @@ def test_note_token_cannot_reinitialize(environment, accounts):
             [accounts[2].address],
             [100_000_000e8],
             accounts[2].address,
+            accounts[2].address,
             {"from": environment.deployer},
         )
 
@@ -77,6 +78,7 @@ def test_note_token_cannot_initialize_duplicates(environment, accounts):
             [accounts[2].address, accounts[2].address],
             [50_000_000e8, 50_000_000e8],
             environment.notional.address,
+            environment.governor.address,
             {"from": environment.deployer},
         )
 
@@ -283,11 +285,38 @@ def test_note_token_reservoir_fails_on_zero(environment, accounts, Reservoir):
         reservoir.drip()
 
 
+def test_non_owners_cannot_upgrade_contracts(environment, accounts):
+    zeroAddress = HexString(0, "bytes20")
+    with brownie.reverts("Ownable: caller is not the owner"):
+        environment.notional.upgradeTo(zeroAddress, {"from": accounts[0]})
+        environment.notional.upgradeToAndCall(zeroAddress, {"from": accounts[0]})
+
+        environment.noteERC20.upgradeTo(zeroAddress, {"from": accounts[0]})
+        environment.noteERC20.upgradeToAndCall(zeroAddress, {"from": accounts[0]})
+
+
+def test_upgrade_note_token(environment, accounts, NoteERC20):
+    environment.noteERC20.delegate(environment.multisig, {"from": environment.multisig})
+    newToken = NoteERC20.deploy({"from": environment.deployer})
+    upgradeToken = web3.eth.contract(abi=environment.noteERC20.abi).encodeABI(
+        fn_name="upgradeTo", args=[newToken.address]
+    )
+    targets = [environment.noteERC20.address]
+    values = [0]
+    calldatas = [upgradeToken]
+
+    prevImplementation = environment.noteERC20Proxy.getImplementation()
+    execute_proposal(environment, targets, values, calldatas)
+
+    assert environment.noteERC20Proxy.getImplementation() == newToken.address
+    assert environment.noteERC20Proxy.getImplementation() != prevImplementation
+
+
 def test_upgrade_router_contract(environment, accounts, Router):
     environment.noteERC20.delegate(environment.multisig, {"from": environment.multisig})
     zeroAddress = HexString(0, "bytes20")
     newRouter = Router.deploy(
-        zeroAddress,
+        environment.router.GOVERNANCE(),
         zeroAddress,
         zeroAddress,
         zeroAddress,
@@ -301,24 +330,18 @@ def test_upgrade_router_contract(environment, accounts, Router):
         {"from": environment.deployer},
     )
 
-    upgradeRouter = web3.eth.contract(abi=environment.proxyAdmin.abi).encodeABI(
-        fn_name="upgrade", args=[environment.proxy.address, newRouter.address]
+    upgradeRouter = web3.eth.contract(abi=environment.notional.abi).encodeABI(
+        fn_name="upgradeTo", args=[newRouter.address]
     )
 
-    targets = [environment.proxyAdmin.address]
+    targets = [environment.notional.address]
     values = [0]
     calldatas = [upgradeRouter]
 
-    prevImplementation = environment.proxyAdmin.getProxyImplementation(environment.proxy.address)
+    prevImplementation = environment.notional.getImplementation()
     execute_proposal(environment, targets, values, calldatas)
-    assert (
-        environment.proxyAdmin.getProxyImplementation(environment.proxy.address)
-        == newRouter.address
-    )
-    assert (
-        environment.proxyAdmin.getProxyImplementation(environment.proxy.address)
-        != prevImplementation
-    )
+    assert environment.notional.getImplementation() == newRouter.address
+    assert environment.notional.getImplementation() != prevImplementation
 
 
 def test_upgrade_governance_contract(environment, accounts, GovernorAlpha):

--- a/tests/governance/test_governance.py
+++ b/tests/governance/test_governance.py
@@ -5,7 +5,7 @@ from brownie.convert.datatypes import HexString
 from brownie.network import web3
 from brownie.network.state import Chain
 from scripts.config import GovernanceConfig
-from scripts.deployment import TestEnvironment
+from scripts.deployment import TestEnvironment, deployNoteERC20
 
 chain = Chain()
 
@@ -415,3 +415,15 @@ def test_pause_and_restart_router(environment, accounts):
 
     # Assert that methods are now callable
     environment.notional.settleAccount(accounts[0])
+
+
+def test_can_delegate_if_notional_not_active(accounts):
+    (_, noteERC20) = deployNoteERC20(accounts[0])
+    noteERC20.initialize(
+        [accounts[2].address], [100_000_000e8], accounts[2].address, {"from": accounts[0]}
+    )
+
+    noteERC20.delegate(accounts[4], {"from": accounts[2]})
+    noteERC20.delegate(accounts[4], {"from": accounts[4]})
+    assert noteERC20.notionalProxy() == "0x0000000000000000000000000000000000000000"
+    assert noteERC20.getCurrentVotes(accounts[4]) == 100_000_000e8


### PR DESCRIPTION
Upgrades the proxy to a more gas efficient version from OZ and gives a `pauseGuardian` address the ability to downgrade the Router to a read only `pauseRouter` during an emergency.